### PR TITLE
Flutter 3.22.2 Updates

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -111,7 +111,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   child: Text('Toggle enablePulsingAnimation',
                       style: Theme.of(context)
                           .textTheme
-                          .button!
+                          .labelLarge!
                           .copyWith(color: Colors.white)),
                 ),
                 const Text(
@@ -126,7 +126,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   child: Text('Toggle overflowMode',
                       style: Theme.of(context)
                           .textTheme
-                          .button!
+                          .labelLarge!
                           .copyWith(color: Colors.white)),
                 ),
                 for (int n = 42; n > 0; n--)
@@ -158,7 +158,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     'Understood',
                     style: Theme.of(context)
                         .textTheme
-                        .button!
+                        .labelLarge!
                         .copyWith(color: Colors.white),
                   ),
                 ),
@@ -168,7 +168,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     'Dismiss',
                     style: Theme.of(context)
                         .textTheme
-                        .button!
+                        .labelLarge!
                         .copyWith(color: Colors.white),
                   ),
                 ),
@@ -201,7 +201,7 @@ class _MyHomePageState extends State<MyHomePage> {
               child: Text('Add another item',
                   style: Theme.of(context)
                       .textTheme
-                      .button!
+                      .labelLarge!
                       .copyWith(color: Colors.white)),
             ),
             for (int n = feature3ItemCount; n > 0; n--)
@@ -234,7 +234,7 @@ class _ContentState extends State<Content> {
     ensureKey = GlobalKey<EnsureVisibleState>();
     ensureKey2 = GlobalKey<EnsureVisibleState>();
 
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       FeatureDiscovery.discoverFeatures(
         context,
         const <String>{
@@ -275,10 +275,10 @@ class _ContentState extends State<Content> {
                 width: double.infinity,
                 padding: const EdgeInsets.all(16.0),
                 color: Colors.blue,
-                child: Column(
+                child: const Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
-                    const Padding(
+                    Padding(
                       padding: EdgeInsets.only(bottom: 8.0),
                       child: Text(
                         'DISH REPUBLIC',
@@ -288,7 +288,7 @@ class _ContentState extends State<Content> {
                         ),
                       ),
                     ),
-                    const Text(
+                    Text(
                       'Eat',
                       style: TextStyle(
                         color: Colors.white,
@@ -314,7 +314,7 @@ class _ContentState extends State<Content> {
                     return true;
                   },
                   onOpen: () async {
-                    WidgetsBinding.instance!.addPostFrameCallback((_) {
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
                       ensureKey!.currentState!.ensureVisible(
                         preciseAlignment: 0.5,
                         duration: const Duration(milliseconds: 400),
@@ -364,7 +364,7 @@ class _ContentState extends State<Content> {
                     return true;
                   },
                   onOpen: () async {
-                    WidgetsBinding.instance!.addPostFrameCallback((_) {
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
                       ensureKey2!.currentState!.ensureVisible(
                           duration: const Duration(milliseconds: 600));
                     });
@@ -380,7 +380,7 @@ class _ContentState extends State<Content> {
                       child: Text('Add item',
                           style: Theme.of(context)
                               .textTheme
-                              .button!
+                              .labelLarge!
                               .copyWith(color: Colors.white)),
                     ),
                     for (int n = feature6ItemCount; n > 0; n--)

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^1.0.8
   feature_discovery:
     path: ../
 

--- a/lib/src/foundation/feature_discovery.dart
+++ b/lib/src/foundation/feature_discovery.dart
@@ -118,7 +118,7 @@ class FeatureDiscovery extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => BlocProvider(
-        child: child,
         persistenceProvider: persistenceProvider,
+        child: child,
       );
 }

--- a/lib/src/foundation/persistence_provider.dart
+++ b/lib/src/foundation/persistence_provider.dart
@@ -40,7 +40,7 @@ class SharedPreferencesProvider implements PersistenceProvider {
   @override
   Future<bool> hasCompletedStep(String featureId) async {
     final prefs = await SharedPreferences.getInstance();
-    final hasCompleted = await prefs.getBool(_normalizeFeatureId(featureId));
+    final hasCompleted = prefs.getBool(_normalizeFeatureId(featureId));
     return hasCompleted == true;
   }
 

--- a/lib/src/widgets/content.dart
+++ b/lib/src/widgets/content.dart
@@ -1,7 +1,6 @@
 import 'package:feature_discovery/src/rendering.dart';
 import 'package:feature_discovery/src/widgets.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 class Content extends StatelessWidget {
   final FeatureOverlayState state;

--- a/lib/src/widgets/ensure_visible.dart
+++ b/lib/src/widgets/ensure_visible.dart
@@ -41,9 +41,9 @@ class EnsureVisibleState extends State<EnsureVisible> {
         'The alignment needs to be null or between 0 and 1.');
 
     final renderObject = context.findRenderObject();
-    final viewport = RenderAbstractViewport.of(renderObject)!;
+    final viewport = RenderAbstractViewport.of(renderObject);
 
-    final scrollableState = Scrollable.of(context)!;
+    final scrollableState = Scrollable.of(context);
 
     final position = scrollableState.position;
     double alignment;

--- a/lib/src/widgets/layout.dart
+++ b/lib/src/widgets/layout.dart
@@ -93,8 +93,8 @@ class _OverlayBuilderState extends State<OverlayBuilder> {
           child: widget.overlayBuilder!(context),
         ),
     );
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
-      Overlay.of(context)!.insert(overlayEntry!);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Overlay.of(context).insert(overlayEntry!);
     });
   }
 
@@ -113,7 +113,7 @@ class _OverlayBuilderState extends State<OverlayBuilder> {
 
   @override
   Widget build(BuildContext context) {
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       buildOverlay();
     });
     return widget.child!;

--- a/lib/src/widgets/overlay.dart
+++ b/lib/src/widgets/overlay.dart
@@ -912,8 +912,8 @@ class _TapTarget extends StatelessWidget {
             child: RawMaterialButton(
               fillColor: color,
               shape: const CircleBorder(),
-              child: child,
               onPressed: onPressed,
+              child: child,
             ),
           ),
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  provider: ^6.0.0
-  shared_preferences: ^2.0.3
+  provider: ^6.1.2
+  shared_preferences: ^2.3.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,8 +22,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  pedantic: 1.9.0
+  pedantic: ^1.11.1
 
 dependency_overrides:
   # TODO(creativecreatorormaybenot): Remove when Pedantic is updated in flutter_test.
-  pedantic: 1.9.0
+  # pedantic: 1.9.0

--- a/test/feature_discovery_test.dart
+++ b/test/feature_discovery_test.dart
@@ -1,6 +1,5 @@
 import 'package:feature_discovery/feature_discovery.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'widgets.dart';
@@ -202,8 +201,7 @@ void main() {
         // The Container that makes the content of the feature overlay of the test widget has a static
         // height of 9e3, which ensures that the content definitely covers the 4e3 surface size height
         // if OverflowMode.clipContent is not enabled.
-        await (TestWidgetsFlutterBinding.ensureInitialized()
-                as TestWidgetsFlutterBinding)
+        await (TestWidgetsFlutterBinding.ensureInitialized())
             .setSurfaceSize(const Size(3e2, 4e3));
 
         await tester.pumpWidget(

--- a/test/widgets.dart
+++ b/test/widgets.dart
@@ -81,10 +81,10 @@ class TestIconState extends State<TestIcon> {
       // Otherwise, the tester can never settle as it requires frame sync.
       enablePulsingAnimation: false,
       allowShowingDuplicate: widget.allowShowingDuplicate,
-      child: icon,
       tapTarget: icon,
       title: const Text('This is it'),
       description: Text('Test has passed for ${widget.featureId}'),
+      child: icon,
     );
   }
 }
@@ -141,7 +141,7 @@ class OverflowingDescriptionFeature extends StatelessWidget {
                     child: Container(
                       width: 1e2,
                       height: 1e2,
-                      color: const Color(0xfffffff),
+                      color: const Color(0xffffffff),
                     ),
                   ),
                 ),


### PR DESCRIPTION
These fixes cleared all of the warnings and errors, but I am still getting the following problem resolving dependencies:

flutter pub upgrade
Resolving dependencies... (12.0s)
Downloading packages...
  leak_tracker 10.0.4 (10.0.5 available)
  leak_tracker_flutter_testing 3.0.3 (3.0.5 available)
  material_color_utilities 0.8.0 (0.12.0 available)
  meta 1.12.0 (1.15.0 available)
! pedantic 1.9.0 (overridden) (discontinued replaced by lints)
  test_api 0.7.0 (0.7.2 available)
  vm_service 14.2.1 (14.2.3 available)
No dependencies changed.
1 package is discontinued.
7 packages have newer versions incompatible with dependency constraints. Try `flutter pub outdated` for more information.
Resolving dependencies in `./example`...
The current Dart SDK version is 3.4.3.

Because example depends on cupertino_icons >=0.1.1 <1.0.1 which doesn't support null safety, version
  solving failed.

The lower bound of "sdk: '<2.0.0 or >=2.0.0-dev.28.0 <3.0.0'" must be 2.12.0 or higher to enable null safety. For details, see https://dart.dev/null-safety

You can try the following suggestion to make the pubspec resolve:
* Try updating the following constraints: flutter pub add cupertino_icons:^1.0.8 feature_discovery:'{"version":"^0.14.1","path":"."}' flutter:'{"version":"^0.0.0","sdk":"flutter"}' dev:pedantic:^1.11.1 dcode@M1Pro-DH feature_discovery % flutter pub outdated Showing outdated packages.
[*] indicates versions that are not the latest available.

Package Name  Current              Upgradable           Resolvable           Latest

direct dependencies: all up-to-date.

dev_dependencies:
pedantic      *1.9.0 (overridden)  *1.9.0 (overridden)  *1.9.0 (overridden)  1.11.1  (discontinued)
You are already using the newest resolvable versions listed in the 'Resolvable' column.
Newer versions, listed in 'Latest', may not be mutually compatible.

pedantic
    Package pedantic has been discontinued, replaced by lints. See https://dart.dev/go/package-discontinue